### PR TITLE
added ssget to the build procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ os:
 
 install:
   - pip install -r requirements.txt
+  - sudo curl -Lo /usr/local/bin/ssget https://raw.githubusercontent.com/ginkgo-project/ssget/master/ssget
 
 script:
   - pytest


### PR DESCRIPTION
Added the installation of the ssget tool to the build proces. This means you can also use ssget on travis and tests using ssget won't fail when run on the CI.